### PR TITLE
Downgrade UPX from 3.95 back to 3.94

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
         working_directory: /tmp
         command: |
           sudo env GOOS=darwin GOARCH=amd64 $(which go) install std
-          wget --quiet https://github.com/upx/upx/releases/download/v3.95/upx-3.95-amd64_linux.tar.xz
-          tar --strip=1 -xf upx-3.95-amd64_linux.tar.xz
+          wget --quiet https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz
+          tar --strip=1 -xf upx-3.94-amd64_linux.tar.xz
           sudo install upx /usr/bin
     - run:
         name: Build binaries


### PR DESCRIPTION
There appears to be an outstanding issue with the official UPX 3.95 release compressing Go binaries built for Darwin. See https://github.com/upx/upx/issues/222 for more details. 