### PR TITLE
add quiet flag

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -191,7 +191,7 @@ func Audit(cfg *config.Config) (map[string][]Violation, int, error) {
 	return violations, total, nil
 }
 
-func AuditPrint(violations map[string][]Violation) {
+func AuditPrint(violations map[string][]Violation, quiet bool) {
 	var (
 		total  = 0
 		names  = make([]string, 0, len(violations))
@@ -208,7 +208,9 @@ func AuditPrint(violations map[string][]Violation) {
 		total += len(violations[name])
 		switch len(violations[name]) {
 		case 0:
-			color.Green("✓ %s\n", name)
+			if !quiet {
+				color.Green("✓ %s\n", name)
+			}
 		default:
 			failed = true
 			color.Red("✗ %s\n", name)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func mainCmd() error {
 		noticeFlag   = flag.Bool("notice", false, "Generate license notice.")
 		scanFlag     = flag.Bool("scan", false, "Scan single dependency.")
 		versionFlag  = flag.Bool("version", false, "Displays the version and exits.")
+		quietFlag    = flag.Bool("quiet", false, "Only print audit entries that fail.")
 	)
 	flag.Parse()
 
@@ -43,7 +44,7 @@ func mainCmd() error {
 		if err != nil {
 			return err
 		}
-		cmd.AuditPrint(violations)
+		cmd.AuditPrint(violations, *quietFlag)
 
 		switch count {
 		case 0:


### PR DESCRIPTION
audit mode only prints failures when -quiet specified.