### PR TITLE
Enable using custom license types

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -65,7 +65,7 @@ func DependencyViolations(name string, dependency config.Dependency, licenseMap 
 	}
 
 	_, found := licenseMap[dependency.License]
-	if !found || !strings.HasPrefix(dependency.License, "Custom: ") {
+	if !found && !strings.HasPrefix(dependency.License, "Custom - ") {
 		violations = append(violations, NewViolation(name, "unknown licence type '"+dependency.License+"'"))
 	}
 


### PR DESCRIPTION
Custom license type can be specified by prefixing it with `Custom - `.