### PR TITLE
ROX-3890: Modify audit command to accept string of JS deps directories

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -55,29 +55,29 @@ func AuditCommand() *cobra.Command {
 
 			var yarnResolved = make(map[string]resolver.Dependency)
 			if len(yarnProjects) > 0 {
-				for _, dir := range cfg.Yarn.NodeModulesDirs {
-					// fmt.Printf("Processing JS deps directory: %s \n", dir)
-					currentDeps, err := resolver.LocateProjects(dir, yarnProjects)
-					if err != nil {
-						return errors.Wrapf(err, "failed to locate js dependencies in dir %q", dir)
-					}
-					for _, v := range currentDeps {
-						// fmt.Printf("Target dependency: %s \n", k)
-						keyWithVersion := v.Name + v.Version
-						// fmt.Printf("Target dependency key with version: %s \n", keyWithVersion)
-
-						yarnResolved[keyWithVersion] = v
-					}
+				dirList := cfg.Yarn.NodeModulesDirs
+				fmt.Printf("Processing JS deps directories: %v \n", dirList)
+				currentDeps, err := resolver.LocateProjects(dirList, yarnProjects)
+				if err != nil {
+					return errors.Wrapf(err, "failed to locate js dependencies in dirs %v", dirList)
 				}
+				for _, v := range currentDeps {
+					fmt.Printf("Target dependency: %s \n", v)
+					keyWithVersion := v.Name + v.Version
+					fmt.Printf("Target dependency key with version: %s \n", keyWithVersion)
+
+					yarnResolved[keyWithVersion] = v
+				}
+
 			}
 
 			var depResolved map[string]resolver.Dependency
 			if len(depProjects) > 0 {
-				depResolved, err = resolver.LocateProjects(cfg.Dep.VendorDir, depProjects)
-				// fmt.Printf("Resolved dependency: %s \n", depResolved)
+				depResolved, err = resolver.LocateProjects(cfg.Dep.VendorDirs, depProjects)
+				fmt.Printf("Resolved dependency: %s \n", depResolved)
 
 				if err != nil {
-					return errors.Wrap(err, "failed to locate go dependencies in dir "+cfg.Dep.VendorDir)
+					return errors.Wrapf(err, "failed to locate go dependencies in dirs %v", cfg.Dep.VendorDirs)
 				}
 			}
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@ type GoModConfig struct {
 }
 
 type DepConfig struct {
-	VendorDir string `yaml:"vendor-dir"`
-	Lockfile  string `yaml:"lockfile"`
+	VendorDirs []string `yaml:"vendor-dirs"`
+	Lockfile   string   `yaml:"lockfile"`
 }
 
 type YarnConfig struct {


### PR DESCRIPTION
This is the minimum viable change to support a monorepo with multiple packages, with potentially multiple `node_modules` directories to scan.

## Changes:
1. Instead of reading a string from `yarn > node-modules-dir` in config file, expect a list of strings in a key with a new name, `yarn > node-modules-dirs`
2. Instead of reading one string from the config, the `audit` command loops through the list of directories and adds the set of packages from each directory to the map of dependencies.

## Areas for improvement:
1. This change requires that the consuming repo manually add each `node_modules` folder that needs to be scanned to the list in its `.ossls.yml` config file. We may be able automate this somewhat by accepting a glob pattern, such as `ui/packages/*/node_modules` (Ivan's suggestion in the Jira ticket comments)
2. The process of combining each set of packages currently does not handle collisions--need to come up with a more robust solution for that.

## Testing
I built a local copy of the modified app, copied it into the `rox` repo, and modified its `.ossls.yml` file from:

```
node-modules-dir: ui/node_modules
```
to
```
node-modules-dirs:
        - ui/node_modules
```

and ran the local built copy of the ossls app.