### PR TITLE
Add support for npm package-lock.json v3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Dep   DepConfig   `json:"dep"`
 	GoMod GoModConfig `json:"gomod"`
 	Yarn  YarnConfig  `json:"yarn"`
+	Npm   NpmConfig   `json:"npm"`
 	PatternConfig
 }
 
@@ -32,6 +33,11 @@ type DepConfig struct {
 type YarnConfig struct {
 	NodeModulesDirs []string `json:"node-modules-dirs"`
 	Lockfile        string   `json:"lockfile"`
+}
+
+type NpmConfig struct {
+	NodeModulesDir string `json:"node-modules-dir"`
+	Lockfile       string `json:"lockfile"`
 }
 
 func Load(filename string) (*Config, error) {

--- a/resolver/npm.go
+++ b/resolver/npm.go
@@ -1,0 +1,78 @@
+package resolver
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+func ProjectsFromNpmLockfileV3(filename string) ([]Project, error) {
+	byteValue, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var packageLock PackageLockV3
+
+	json.Unmarshal(byteValue, &packageLock)
+
+	return asNpmProjects(packageLock), nil
+}
+
+type NpmProject struct {
+	name     string
+	version  string
+	optional bool
+}
+
+var _ Project = (*NpmProject)(nil)
+
+func (p NpmProject) Name() string {
+	return p.name
+}
+
+func (p NpmProject) Optional() bool {
+	return p.optional
+}
+
+func (p NpmProject) Version() string {
+	return p.version
+}
+
+type PackageLockV3 struct {
+	Name     string                `json:"name"`
+	Version  string                `json:"version"`
+	Packages map[string]NpmPackage `json:"packages"`
+}
+
+type NpmPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func asNpmProjects(packageLock PackageLockV3) []Project {
+	projectSet := make(map[string]NpmProject, len(packageLock.Packages)-1)
+
+	for pkg, entry := range packageLock.Packages {
+		if pkg == "" {
+			// skip the top-level package as it refers to the project itself
+			continue
+		}
+
+		projectSet[pkg] = NpmProject{
+			// Remove the `node_modules/` root directory prefix from each `pkg`
+			name:    strings.Replace(pkg, "node_modules/", "", 1),
+			version: entry.Version,
+			// optional packages that are included as dependencies in the build will be declared at the top
+			// level of packageLock.Packages, so we can explicitly mark optional as false here
+			optional: false,
+		}
+	}
+
+	projectList := make([]Project, 0)
+	for _, project := range projectSet {
+		projectList = append(projectList, project)
+	}
+
+	return projectList
+}

--- a/resolver/npm.go
+++ b/resolver/npm.go
@@ -61,7 +61,7 @@ func asNpmProjects(packageLock PackageLockV3) []Project {
 
 		projectSet[pkg] = NpmProject{
 			// Remove the `node_modules/` root directory prefix from each `pkg`
-			name:    strings.Replace(pkg, "node_modules/", "", 1),
+			name:    strings.TrimPrefix(pkg, "node_modules/"),
 			version: entry.Version,
 			// optional packages that are included as dependencies in the build will be declared at the top
 			// level of packageLock.Packages, so we can explicitly mark optional as false here
@@ -69,7 +69,7 @@ func asNpmProjects(packageLock PackageLockV3) []Project {
 		}
 	}
 
-	projectList := make([]Project, 0)
+	projectList := make([]Project, 0, len(projectSet))
 	for _, project := range projectSet {
 		projectList = append(projectList, project)
 	}

--- a/resolver/npm_test.go
+++ b/resolver/npm_test.go
@@ -1,0 +1,42 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectsFromNpmLockfileV3(t *testing.T) {
+	actualProjects, err := ProjectsFromNpmLockfileV3("testdata/package-lock.json")
+
+	expectedProjects := make(map[string]NpmProject, 4)
+	expectedProjects["@aashutoshrathi/word-wrap"] = NpmProject{
+		name:     "@aashutoshrathi/word-wrap",
+		optional: false,
+		version:  "1.2.6",
+	}
+	expectedProjects["@adobe/css-tools"] = NpmProject{
+		name:     "@adobe/css-tools",
+		optional: false,
+		version:  "4.3.2",
+	}
+	expectedProjects["yup/node_modules/type-fest"] = NpmProject{
+		name:     "yup/node_modules/type-fest",
+		optional: false,
+		version:  "2.19.0",
+	}
+	expectedProjects["@apollo/client"] = NpmProject{
+		name:     "@apollo/client",
+		optional: false,
+		version:  "3.8.7",
+	}
+
+	require.Nil(t, err)
+
+	for _, actualProject := range actualProjects {
+		expectedProject, ok := expectedProjects[actualProject.Name()]
+		require.True(t, ok)
+		assert.Equal(t, expectedProject, actualProject)
+	}
+}

--- a/resolver/npm_test.go
+++ b/resolver/npm_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestProjectsFromNpmLockfileV3(t *testing.T) {
 	actualProjects, err := ProjectsFromNpmLockfileV3("testdata/package-lock.json")
+	require.Nil(t, err)
 
 	expectedProjects := make(map[string]NpmProject, 4)
 	expectedProjects["@aashutoshrathi/word-wrap"] = NpmProject{
@@ -31,8 +32,6 @@ func TestProjectsFromNpmLockfileV3(t *testing.T) {
 		optional: false,
 		version:  "3.8.7",
 	}
-
-	require.Nil(t, err)
 
 	for _, actualProject := range actualProjects {
 		expectedProject, ok := expectedProjects[actualProject.Name()]

--- a/resolver/projects.go
+++ b/resolver/projects.go
@@ -24,6 +24,8 @@ type Dependency struct {
 	Version   string
 }
 
+var nodeModulePrefixRegexp = regexp.MustCompile(`.*node_modules\/`)
+
 func LocateGoModProjects(projects []GoModProject) (map[string]Dependency, error) {
 	deps := make(map[string]Dependency, len(projects))
 
@@ -40,14 +42,18 @@ func LocateGoModProjects(projects []GoModProject) (map[string]Dependency, error)
 }
 
 func LocateNpmPackageLockV3Projects(root string, projects []Project) (map[string]Dependency, error) {
-	nodeModulePrefixRegexp := regexp.MustCompile(`.*node_modules\/`)
 	deps := make(map[string]Dependency, len(projects))
 
 	for _, project := range projects {
 		baseDependencyName := nodeModulePrefixRegexp.ReplaceAllString(project.Name(), "")
 		sourceDir := filepath.Join(root, project.Name())
 		if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
-			// If a direct path to a nested dependency is not found, it was hoisted to the root.
+			// If a direct path to a nested dependency is not found, it was hoisted to the root to
+			// be shared among multiple parent dependencies.
+			//
+			// e.g. If multiple dependencies share a common transitive dependency on `type-fest`, the
+			// path `node_modules/yup/node_modules/type-fest` could become `node_modules/type-fest`
+			// when installed on disk.
 			sourceDir = filepath.Join(root, baseDependencyName)
 		}
 		dep := Dependency{

--- a/resolver/testdata/package-lock.json
+++ b/resolver/testdata/package-lock.json
@@ -1,0 +1,82 @@
+{
+  "name": "@stackrox/platform-app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stackrox/platform-app",
+      "version": "0.0.0",
+      "license": "UNLICENSED",
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha1-vZFUrsmYP3ezoDTsqgFcLkIB9s8= sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha1-pqvHFftohIUfyp2tN/w0c5oE/RE= sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
+      "dev": true
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha1-iAaAFbszA2pZi5UuVekxGmD9Ops= sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.7.tgz",
+      "integrity": "sha1-CQsVGPUTUDuaamkO4+rsSVKYIuE= sha512-DnQtFkQrCyxHTSa9gR84YRLmU/al6HeXcLZazVe+VxKBmx/Hj4rV8xWtzfWYX5ijartsqDR7SJgV037MATEecA==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.17.5",
+        "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for npm's `package-lock.json` (v3) as an alternative to yarn's custom `yarn.lock` file. This would allow the stackrox UI to drop yarn in favor of npm in order to enable hermetic builds in the konflux pipelines.


This update includes dev dependencies as well as nested transitive dependencies in the output. Essentially if a module is resolved somewhere in the application's `node_modules` folder, it will be included in the ossls notice output with a LICENSE file and license.json metadata. It would not be difficult to drop either of these dependency categories if needed, but I didn't see the harm in including them. 

(As an aside, this means the dependencies included by the current yarn version could change depending on how the tree is resolved. e.g. If we depend on `yaml1.7.2` at the top level and `yaml2.2.1` as a nested dependency, the latter would not be included in the license output. In theory a dependency change could invert the two, in which case the _former_ would not be included in the output.)

## How it works

The npm package-lock.json v3 contains a `packages` key with a value object where:
1. The first object key is `""`, which contains metadata about the root project. This is ignored.
2. All other keys are in the form of `"node_modules/<package-name>"` or `"node_modules/<package-name>/node_modules/<nested-package-name>"`. The values to these keys contain metadata about the package, the only data which we care about being the `version` field.

This code update reads all of the keys from 2 above and treats:
1. The full key, containing all `node_modules` segments as the expected path of the module on disk
2. The substring of the key removing all prefix up to and including the last `"node_modules"` segment as the package name
3. The `version` field of the object as the package version

Once the paths, names, and versions for all modules are obtained, control is returned back to the existing ossls code which then reads metadata and license information for all of these packages and outputs the results on disk.

## Testing

Manual testing against the full `package-lock.json` in https://github.com/stackrox/stackrox/pull/11967 and compare to similar output against the yarn equivalent in `stackrox@master`.

```sh
# With the package-lock.json and updated .ossls.yml config in #11967

go build && mv ossls ~/bin
cd ~/projects/stackrox
rm -rf image/rhel/THIRD_PARTY_NOTICES
make ossls-notice
ls image/rhel/THIRD_PARTY_NOTICES
```

```sh
...
workbox-strategies6.5.4
workbox-streams6.5.4
workbox-sw6.5.4
workbox-webpack-plugin6.5.4
workbox-window6.5.4
workerpool6.5.1
wrap-ansi6.2.0
wrap-ansi7.0.0
wrappy1.0.2
write-file-atomic4.0.2
ws8.17.1
xml-name-validator4.0.0
xml1.0.1
xmlchars2.2.0
xtend4.0.2
y18n5.0.5
yallist3.1.1
yallist4.0.0
yaml-ast-parser0.0.43
yaml1.10.2
yaml1.7.2
yaml2.2.1
yargs-parser20.2.9
yargs-parser21.1.1
yargs-unparser2.0.0
yargs16.2.0
yargs17.7.2
yauzl2.10.0
yocto-queue0.1.0
yup1.4.0
zen-observable-ts1.2.5
zen-observable0.8.15
```

```sh
$ cat yup1.4.0/*
# LICENSE

The MIT License (MIT)

Copyright (c) 2014 Jason Quense

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.

# license-info.json

{
  "license": "MIT",
  "metadata": {
    "author": {
      "name": "@monasticpanic Jason Quense"
    },
    "name": "yup",
    "repository": {
      "type": "git",
      "url": "git+https://github.com/jquense/yup.git"
    }
  }
}
```

Automated unit test included with this PR.

