### PR TITLE
Skip uninstalled, optional npm dependencies

### DIFF
--- a/resolver/npm.go
+++ b/resolver/npm.go
@@ -46,8 +46,9 @@ type PackageLockV3 struct {
 }
 
 type NpmPackage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Optional bool   `json:"optional"`
 }
 
 func asNpmProjects(packageLock PackageLockV3) []Project {
@@ -61,11 +62,9 @@ func asNpmProjects(packageLock PackageLockV3) []Project {
 
 		projectSet[pkg] = NpmProject{
 			// Remove the `node_modules/` root directory prefix from each `pkg`
-			name:    strings.TrimPrefix(pkg, "node_modules/"),
-			version: entry.Version,
-			// optional packages that are included as dependencies in the build will be declared at the top
-			// level of packageLock.Packages, so we can explicitly mark optional as false here
-			optional: false,
+			name:     strings.TrimPrefix(pkg, "node_modules/"),
+			version:  entry.Version,
+			optional: entry.Optional,
 		}
 	}
 

--- a/resolver/projects.go
+++ b/resolver/projects.go
@@ -61,6 +61,14 @@ func LocateNpmPackageLockV3Projects(root string, projects []Project) (map[string
 			Version:   project.Version(),
 			SourceDir: sourceDir,
 		}
+
+		// If the dependency is optional and not found, skip adding it, as it may not be installed.
+		// This is common for optional dependencies targeting a platform other
+		// than the host platform.
+		if _, err := os.Stat(sourceDir); os.IsNotExist(err) && project.Optional() {
+			continue
+		}
+
 		deps[baseDependencyName+dep.Version] = dep
 	}
 


### PR DESCRIPTION
This change will skip adding `npm` dependencies to the THIRD_PARTY_NOTICES license output when both of the following are true:
1. The dependency is marked as `optional`
2. The dependency is not detected to be installed on disk

This is needed due to `optional` dependencies that target a platform other than the current platform not being installed, and causing `ossls` to fail otherwise. This is the case with `fsevents` (which is optional and only installs on darwin based systems) not being installed on linux during CI.

## Testing

Before change, with all modules installed:
```
$ ls -lah image/rhel/THIRD_PARTY_NOTICES | wc -l
    2368
```

After change, with all modules installed:
```
$ ls -lah image/rhel/THIRD_PARTY_NOTICES | wc -l
    2368
```

Manually delete `ui/apps/platform/node_modules/fsevents`, which has an optional package-lock entry of:
```
         node_modules/fsevents : {
             version :  2.3.2 ,
             resolved :  https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz ,
             integrity :  sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro= sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA== ,
             dev : true,
             hasInstallScript : true,
             optional : true,
             os : [
                 darwin
            ],
             engines : {
                 node :  ^8.16.0 || ^10.6.0 || >=11.0.0
            }
        }
```

After deletion, the program runs successfully and outputs one less directory:
```
$ ls -lah image/rhel/THIRD_PARTY_NOTICES | wc -l
    2367
```

Delete a non-optional dependency, and `ossls` fails as expected:
```
ossls: resolving dependencies: finding license files in directory ui/apps/platform/node_modules/yup: reading directory ui/apps/platform/node_modules/yup: open ui/apps/platform/node_modules/yup: no such file or directory
make: *** [ossls-notice] Error 1
```

Also tested end-to-end with:
- A pre-release version of ossls in this repo https://github.com/stackrox/ossls/releases/tag/0.11.1-rc1
- Added to a development build of rox-ci-image https://github.com/stackrox/ossls/releases/tag/0.11.1-rc1
- A successful build in stackrox/stackrox referencing the dev build of rox-ci-image, with npm dependency output https://github.com/stackrox/stackrox/actions/runs/10373145603/job/28718131269?pr=12373